### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Done!
 You might want to run rebuildrecentchanges.php to regenerate RecentChanges
 ```
 
-Log in as the Mediawiki adminstrator.
+Log in as the Mediawiki administrator.
 
 Refresh the main page. A 'Transcription Desk' link should appears in the left panel under 'Navigation'.
 


### PR DESCRIPTION
@onothimagen, I've corrected a typographical error in the documentation of the [cbp-transcription-desk](https://github.com/onothimagen/cbp-transcription-desk) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
